### PR TITLE
Add orientation display and refine robot rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,10 @@
     <button id="playBtn">Play Ghost</button>
     <span style="margin-left:auto;opacity:.7">LS=move, RS-X=rotate, <span class="k">Y</span> mode, <span class="k">A</span> reset</span>
   </header>
-  <canvas id="c" width="1280" height="720"></canvas>
+  <div id="sim">
+    <canvas id="c" width="1280" height="720"></canvas>
+    <canvas id="orient" width="200" height="200"></canvas>
+  </div>
 </div>
 
 <div id="hud">

--- a/style.css
+++ b/style.css
@@ -6,7 +6,10 @@ select, button { background:#141a22; color:#e7eef7; border:1px solid #273241; bo
 button { cursor:pointer; }
 #hud { position:fixed; top:60px; left:12px; background:#141a22cc; padding:10px 12px; border-radius:10px; backdrop-filter: blur(6px); }
 .k { color:#9ecbff }
-canvas { flex:1; display:block; background:#0e131a; }
+#sim { flex:1; display:flex; }
+#c { flex:1; }
+#orient { flex:none; width:200px; height:200px; margin-left:10px; background:#0e131a; border-left:1px solid #15202b; }
+canvas { display:block; background:#0e131a; }
 #calPanel { position:fixed; right:12px; top:60px; width:340px; background:#10161d; border:1px solid #1f2a36; border-radius:12px; padding:12px; display:none; }
 #calPanel h3 { margin:0 0 8px; font-size:15px; color:#cde3ff; }
 #calPanel label { display:block; margin:8px 0 4px; color:#a7b6c7; font-size:13px; }


### PR DESCRIPTION
## Summary
- Render a realistic FRC chassis without wheel direction arrows
- Add side orientation window showing robot heading and wheel angles

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689be895a510832584a61dd91d2f327c