### PR TITLE
Add control mode selector and simplified robot view

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,11 @@
     <select id="ratioSel"></select>
     <label class="k">Profile</label>
     <select id="profileSel"></select>
+    <label class="k">Mode</label>
+    <select id="modeSel">
+      <option value="field">Field-centric</option>
+      <option value="robot">Robot-centric</option>
+    </select>
     <button id="calBtn">Calibrate</button>
     <button id="defBtn">Defender: Off</button>
     <button id="recBtn">Record Ghost</button>


### PR DESCRIPTION
## Summary
- default to field-centric driving and allow mode selection via UI
- remove wheel rendering on field robot and label all bumpers with 7190

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689bee23b1a48325a25c3822d8a3c798