### PR TITLE
Scale sim window and refine robot rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     <span style="margin-left:auto;opacity:.7">LS=move, RS-X=rotate, <span class="k">Y</span> mode, <span class="k">A</span> reset</span>
   </header>
   <div id="sim">
-    <canvas id="c" width="1280" height="720"></canvas>
+    <canvas id="c"></canvas>
     <canvas id="orient" width="200" height="200"></canvas>
   </div>
 </div>

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ button { cursor:pointer; }
 #hud { position:fixed; top:60px; left:12px; background:#141a22cc; padding:10px 12px; border-radius:10px; backdrop-filter: blur(6px); }
 .k { color:#9ecbff }
 #sim { flex:1; display:flex; }
-#c { flex:1; }
+#c { flex:1; width:100%; height:100%; }
 #orient { flex:none; width:200px; height:200px; margin-left:10px; background:#0e131a; border-left:1px solid #15202b; }
 canvas { display:block; background:#0e131a; }
 #calPanel { position:fixed; right:12px; top:60px; width:340px; background:#10161d; border:1px solid #1f2a36; border-radius:12px; padding:12px; display:none; }


### PR DESCRIPTION
## Summary
- Scale simulation canvas to fit the browser window and rescale field elements on resize
- Render swerve modules and thicker bumpers with proportionally smaller numbers
- Remove fixed canvas size and make canvas fill the screen

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_689bf29ca5c48325af4fbbb4fa6c8831