### PR TITLE
Fix left joystick axis mapping

### DIFF
--- a/app.js
+++ b/app.js
@@ -143,8 +143,8 @@ function consumeInput(){
   lastY = inp.btnY;
   if (inp.btnA && !lastA){ resetCycle(); }
   lastA = inp.btnA;
-  let vx = -inp.ly * lim.vFree;
-  let vy =  inp.lx * lim.vFree;
+  let vx =  inp.lx * lim.vFree;
+  let vy = -inp.ly * lim.vFree;
   let om =  inp.rx * (lim.vFree / (Math.hypot(profile.wheelbase_m, profile.track_m)/2));
   if (!fieldCentric){ [vx, vy] = rotF(vx, vy, pose.th); }
   velCmd.vx = vx; velCmd.vy = vy; velCmd.om = om;


### PR DESCRIPTION
## Summary
- Correct the mapping of left joystick axes so forward/backward and strafe inputs are not rotated 90°

## Testing
- `node --check app.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bf4a52be08325b8140a5242d4fd2f