### PR TITLE
Fix left stick horizontal axis inversion

### DIFF
--- a/app.js
+++ b/app.js
@@ -116,7 +116,7 @@ function pollGamepad(){
     inputQ.push({t, lx:0, ly:0, rx:0, btnY:false, btnA:false});
     return;
   }
-  const lx = db(gp.axes[0] ?? 0, profile.deadband);
+  const lx = db(-(gp.axes[0] ?? 0), profile.deadband);
   const ly = db(gp.axes[1] ?? 0, profile.deadband);
 
   // Different controllers expose the right stick X axis at different indices.


### PR DESCRIPTION
## Summary
- Correct left joystick horizontal axis sign in gamepad polling to match expected direction

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node app.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689bf66f56048325a0bd8e4eb0fe8018