### PR TITLE
Scale robot orientation view to fit at 45°

### DIFF
--- a/app.js
+++ b/app.js
@@ -205,9 +205,12 @@ function drawOrientationWindow(){
   orientCtx.clearRect(0,0,orientCanvas.width, orientCanvas.height);
   orientCtx.save();
   orientCtx.translate(orientCanvas.width/2, orientCanvas.height/2);
-  const scale = 40;
-  const fac = scale / field.pxPerM;
   const track = profile.track_m, wheelbase = profile.wheelbase_m;
+  const outerLm = wheelbase + 2*BUMPER_M;
+  const outerWm = track + 2*BUMPER_M;
+  const maxScale = Math.min(orientCanvas.width, orientCanvas.height) * Math.SQRT2 / (outerLm + outerWm);
+  const scale = maxScale * 0.95;
+  const fac = scale / field.pxPerM;
   const frameW = track * scale, frameL = wheelbase * scale;
   const bpx = BUMPER_M * scale;
   const outerW = frameW + 2*bpx, outerL = frameL + 2*bpx;


### PR DESCRIPTION
## Summary
- Dynamically compute orientation window scale so the robot fits when rotated 45° with slight margin

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689bf945d4fc83258d7e55431c5ef3e6