### PR TITLE
Add configurable start screen and bumper color selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,16 +7,26 @@
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
+<div id="startScreen">
+  <h2>Templeton Swerve Trainer — MAXSwerve</h2>
+  <label class="k">Motor</label>
+  <select id="motorSel">
+    <option value="NEO">NEO V1.1</option>
+    <option value="VORTEX">NEO Vortex</option>
+  </select>
+  <label class="k">Drive Ratio</label>
+  <select id="ratioSel"></select>
+  <label class="k">Bumper Color</label>
+  <select id="bumperSel">
+    <option value="red">Red</option>
+    <option value="blue">Blue</option>
+  </select>
+  <button id="startBtn">Start</button>
+</div>
+
 <div id="wrap">
   <header>
     <h1>Templeton Swerve Trainer — MAXSwerve</h1>
-    <label class="k">Motor</label>
-    <select id="motorSel">
-      <option value="NEO">NEO V1.1</option>
-      <option value="VORTEX">NEO Vortex</option>
-    </select>
-    <label class="k">Drive Ratio</label>
-    <select id="ratioSel"></select>
     <label class="k">Profile</label>
     <select id="profileSel"></select>
     <label class="k">Mode</label>
@@ -28,6 +38,7 @@
     <button id="defBtn">Defender: Off</button>
     <button id="recBtn">Record Ghost</button>
     <button id="playBtn">Play Ghost</button>
+    <button id="homeBtn">Return to Start</button>
     <span style="margin-left:auto;opacity:.7">LS=move, RS-X=rotate, <span class="k">Y</span> mode, <span class="k">A</span> reset</span>
   </header>
   <div id="sim">

--- a/style.css
+++ b/style.css
@@ -4,6 +4,9 @@ header { padding:10px 14px; background:#0e131a; display:flex; flex-wrap:wrap; al
 header h1 { font-size:16px; margin:0; color:#cde3ff; white-space:nowrap }
 select, button { background:#141a22; color:#e7eef7; border:1px solid #273241; border-radius:10px; padding:8px 10px; }
 button { cursor:pointer; }
+#startScreen { position:fixed; top:0; left:0; width:100%; height:100%; background:#0b0f14; display:flex; flex-direction:column; justify-content:center; align-items:center; gap:10px; z-index:100; }
+#startScreen h2 { margin-bottom:10px; color:#cde3ff; }
+#startScreen label { margin-top:6px; }
 #hud { position:fixed; top:60px; left:12px; background:#141a22cc; padding:10px 12px; border-radius:10px; backdrop-filter: blur(6px); }
 .k { color:#9ecbff }
 #sim { flex:1; display:flex; }


### PR DESCRIPTION
## Summary
- Add full-screen start menu with motor, gear ratio, and bumper color options
- Remove motor/gear ratio controls from in-game header and add return-to-start button
- Support selected bumper color in robot rendering and start/stop lifecycle

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_689c003dcd0483258bad5a056261ce6b