### PR TITLE
Sync bumper colour in orientation preview

### DIFF
--- a/app.js
+++ b/app.js
@@ -234,7 +234,7 @@ function drawOrientationWindow(){
   orientCtx.rotate(pose.th);
   orientCtx.fillStyle = '#253140';
   roundRectPath(orientCtx, -frameL/2, -frameW/2, frameL, frameW, 10*fac); orientCtx.fill();
-  orientCtx.fillStyle = '#7c2331';
+  orientCtx.fillStyle = bumperColor;
   orientCtx.fillRect(-outerL/2, -outerW/2, outerL, bpx);
   orientCtx.fillRect(-outerL/2, outerW/2 - bpx, outerL, bpx);
   orientCtx.fillRect(outerL/2 - bpx, -outerW/2, bpx, outerW);


### PR DESCRIPTION
## Summary
- Use selected bumper colour when rendering the orientation preview so it matches the main simulation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c02ab3f948325ba2c2327ae4e013e