### PR TITLE
Add ball pickup and layout options

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,12 @@
   </select>
   <label class="k">Drive Ratio</label>
   <select id="ratioSel"></select>
+  <label class="k">Layout</label>
+  <select id="layoutSel">
+    <option value="default">Default</option>
+    <option value="clear">Clear Field</option>
+    <option value="obstacle">Obstacle Course</option>
+  </select>
   <label class="k">Bumper Color</label>
   <select id="bumperSel">
     <option value="red">Red</option>


### PR DESCRIPTION
## Summary
- Replace pickup zone circle with a ball that can be carried and scored in a wall goal
- Show the carried ball on the robot and add a wall-mounted goal that requires facing it to score
- Add selectable practice layouts on the start screen

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689c058673108325a2e9b8c047484b3e