### PR TITLE
Add hitbox-based scoring and new course layouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
     <option value="default">Default</option>
     <option value="clear">Clear Field</option>
     <option value="obstacle">Obstacle Course</option>
+    <option value="slalom">Slalom</option>
+    <option value="gauntlet">Gauntlet</option>
+    <option value="cluster">Cluster</option>
   </select>
   <label class="k">Bumper Color</label>
   <select id="bumperSel">


### PR DESCRIPTION
## Summary
- Detect scoring with circle-rect overlap between carried ball and goal
- Move goal inward and use hitbox checks when picking up the ball
- Add Slalom, Gauntlet, and Cluster course layouts with selection options

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c07e89de0832585787c29256a95fc