### PR TITLE
Enhance defender and configuration options

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,8 @@
     <option value="gauntlet">Gauntlet</option>
     <option value="cluster">Cluster</option>
   </select>
+  <label class="k">Team Number</label>
+  <input id="teamNum" value="7190" />
   <label class="k">Bumper Color</label>
   <select id="bumperSel">
     <option value="red">Red</option>


### PR DESCRIPTION
## Summary
- Allow entering a custom team number on the start screen
- Render defender as a full chassis with opposite bumpers and no intake
- Scale obstacle sizes with sim scale and let defender collide with them

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c0f3aac208325870f9a064fbf66b2